### PR TITLE
Fix a typo in the missing "as" error message

### DIFF
--- a/parse/Parse.go
+++ b/parse/Parse.go
@@ -33,7 +33,7 @@ func Build(args []string) (util.SumoOperator, error) {
 	}
 	as := args[2]
 	if as != "as" {
-		return nil, util.ParseError("Expacted `as` got " + as + "\n" + genericError)
+		return nil, util.ParseError("Expected `as` got " + as + "\n" + genericError)
 	}
 	extractions := make([]string, len(args) - 3)
 	for i, arg := range args[3:] {


### PR DESCRIPTION
The "missing 'as'" error message had a typo: "expacted" should be "expected".